### PR TITLE
Updated extension to support other cloud instances (not only public Azure cloud)

### DIFF
--- a/terraform/src/index.ts
+++ b/terraform/src/index.ts
@@ -8,7 +8,7 @@ import {
     WorkspaceCommandBuilder,
     StoreOutputCommandBuilder,
 } from './terraformCommandBuilder';
-import { downloadTerraform, loginAzure, isVersionValid } from './utilities';
+import { downloadTerraform, setAzureCloudBasedOnServiceEndpoint, loginAzure, isVersionValid } from './utilities';
 
 async function run() {
     try {
@@ -27,6 +27,7 @@ async function run() {
         }
 
         if (tl.getBoolInput('useazurerm', true)) {
+            setAzureCloudBasedOnServiceEndpoint();
             loginAzure();
         }
 

--- a/terraform/src/package.json
+++ b/terraform/src/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.3",
     "@types/mocha": "^5.2.1",
-    "@types/node": "^10.1.2",
+    "@types/node": "^13.11.1",
     "@types/node-fetch": "^1.6.9",
     "@types/q": "^1.5.0",
     "chai": "^4.1.2",

--- a/terraform/src/utilities.ts
+++ b/terraform/src/utilities.ts
@@ -75,6 +75,29 @@ function sevenZipExtract(file: string, destinationFolder: string): void {
     let result = zip.execSync();
 }
 
+export function setAzureCloudBasedOnServiceEndpoint() {
+    var connectedService: string = tl.getInput("connectedServiceNameARM", true);
+    var environment = tl.getEndpointDataParameter(connectedService, "environment", true);
+    if(!!environment) {
+        throwIfError(tl.execSync("az", "cloud set -n " + environment));
+        if (environment == "AzureCloud") {
+            process.env.ARM_ENVIRONMENT = "public";
+        }
+        else if (environment == "AzureChinaCloud") {
+            process.env.ARM_ENVIRONMENT = "china";
+        }
+        else if (environment == "AzureGermanCloud") {
+            process.env.ARM_ENVIRONMENT = "german";
+        }
+        else if (environment == "AzureUSGovernment") {
+            process.env.ARM_ENVIRONMENT = "usgovernment";
+        }
+    }
+    else {
+        process.env.ARM_ENVIRONMENT = "public";
+    }
+}
+
 export function loginAzure() {
     var connectedService: string = tl.getInput("connectedServiceNameARM", true);
     loginAzureRM(connectedService);

--- a/v2/common/utilities.d.ts
+++ b/v2/common/utilities.d.ts
@@ -1,3 +1,4 @@
 export declare function downloadTerraform(workingDirectory: string, version: string): Promise<void>;
 export declare function loginAzure(): void;
+export declare function setAzureCloudBasedOnServiceEndpoint(): void;
 export declare function isVersionValid(version: string): boolean;

--- a/v2/common/utilities.js
+++ b/v2/common/utilities.js
@@ -92,6 +92,29 @@ function sevenZipExtract(file, destinationFolder) {
     zip.arg("-aoa");
     let result = zip.execSync();
 }
+function setAzureCloudBasedOnServiceEndpoint() {
+    var connectedService = tl.getInput("connectedServiceNameARM", true);
+    var environment = tl.getEndpointDataParameter(connectedService, "environment", true);
+    if(!!environment) {
+        throwIfError(tl.execSync("az", "cloud set -n " + environment));
+        if (environment == "AzureCloud") {
+            process.env.ARM_ENVIRONMENT = "public";
+        }
+        else if (environment == "AzureChinaCloud") {
+            process.env.ARM_ENVIRONMENT = "china";
+        }
+        else if (environment == "AzureGermanCloud") {
+            process.env.ARM_ENVIRONMENT = "german";
+        }
+        else if (environment == "AzureUSGovernment") {
+            process.env.ARM_ENVIRONMENT = "usgovernment";
+        }
+    }
+    else {
+        process.env.ARM_ENVIRONMENT = "public";
+    }
+}
+exports.setAzureCloudBasedOnServiceEndpoint = setAzureCloudBasedOnServiceEndpoint;
 function loginAzure() {
     var connectedService = tl.getInput("connectedServiceNameARM", true);
     loginAzureRM(connectedService);

--- a/v2/common/utilities.ts
+++ b/v2/common/utilities.ts
@@ -75,6 +75,29 @@ function sevenZipExtract(file: string, destinationFolder: string): void {
     let result = zip.execSync();
 }
 
+export function setAzureCloudBasedOnServiceEndpoint() {
+    var connectedService: string = tl.getInput("connectedServiceNameARM", true);
+    var environment = tl.getEndpointDataParameter(connectedService, "environment", true);
+    if(!!environment) {
+        throwIfError(tl.execSync("az", "cloud set -n " + environment));
+        if (environment == "AzureCloud") {
+            process.env.ARM_ENVIRONMENT = "public";
+        }
+        else if (environment == "AzureChinaCloud") {
+            process.env.ARM_ENVIRONMENT = "china";
+        }
+        else if (environment == "AzureGermanCloud") {
+            process.env.ARM_ENVIRONMENT = "german";
+        }
+        else if (environment == "AzureUSGovernment") {
+            process.env.ARM_ENVIRONMENT = "usgovernment";
+        }
+    }
+    else {
+        process.env.ARM_ENVIRONMENT = "public";
+    }
+}
+
 export function loginAzure() {
     var connectedService: string = tl.getInput("connectedServiceNameARM", true);
     loginAzureRM(connectedService);

--- a/v2/terraformapply/index.ts
+++ b/v2/terraformapply/index.ts
@@ -1,7 +1,7 @@
 import * as tl from 'azure-pipelines-task-lib';
 import fs = require('fs');
 import { ApplyCommandBuilder } from '../common/terraformCommandBuilder'
-import { loginAzure } from "../common/utilities";
+import { loginAzure, setAzureCloudBasedOnServiceEndpoint } from "../common/utilities";
 
 async function run() {
     try {
@@ -11,6 +11,7 @@ async function run() {
         }
 
         if (tl.getBoolInput('useazurerm', true)) {
+            setAzureCloudBasedOnServiceEndpoint();
             loginAzure();
         }
 

--- a/v2/terraformdestroy/index.ts
+++ b/v2/terraformdestroy/index.ts
@@ -1,7 +1,7 @@
 import * as tl from 'azure-pipelines-task-lib';
 import fs = require('fs');
 import { DestroyCommandBuilder } from '../common/terraformCommandBuilder'
-import { loginAzure } from '../common/utilities';
+import { loginAzure, setAzureCloudBasedOnServiceEndpoint } from '../common/utilities';
 
 async function run() {
     try {
@@ -11,6 +11,7 @@ async function run() {
         }
 
         if (tl.getBoolInput('useazurerm', true)) {
+            setAzureCloudBasedOnServiceEndpoint();
             loginAzure();
         }
 

--- a/v2/terraforminit/index.ts
+++ b/v2/terraforminit/index.ts
@@ -2,7 +2,7 @@ import tr from "azure-pipelines-task-lib/toolrunner";
 import * as tl from 'azure-pipelines-task-lib';
 import fs = require('fs');
 import { InitCommandBuilder } from '../common/terraformCommandBuilder'
-import { loginAzure } from '../common/utilities';
+import { loginAzure, setAzureCloudBasedOnServiceEndpoint } from '../common/utilities';
 
 async function run() {
     try {
@@ -12,6 +12,7 @@ async function run() {
         }
 
         if (tl.getBoolInput('useazurerm', true)) {
+            setAzureCloudBasedOnServiceEndpoint();
             loginAzure();
         }
 

--- a/v2/terraformoutput/index.ts
+++ b/v2/terraformoutput/index.ts
@@ -2,7 +2,7 @@ import tr from "azure-pipelines-task-lib/toolrunner";
 import * as tl from 'azure-pipelines-task-lib';
 import fs = require('fs');
 import { StoreOutputCommandBuilder } from '../common/terraformCommandBuilder'
-import { loginAzure } from "../common/utilities";
+import { loginAzure, setAzureCloudBasedOnServiceEndpoint } from "../common/utilities";
 
 async function run() {
     try {
@@ -12,6 +12,7 @@ async function run() {
         }
 
         if (tl.getBoolInput('useazurerm', true)) {
+            setAzureCloudBasedOnServiceEndpoint();
             loginAzure();
         }
 

--- a/v2/terraformplan/index.ts
+++ b/v2/terraformplan/index.ts
@@ -2,7 +2,7 @@ import tr from "azure-pipelines-task-lib/toolrunner";
 import * as tl from 'azure-pipelines-task-lib';
 import fs = require('fs');
 import { PlanCommandBuilder } from '../common/terraformCommandBuilder'
-import { loginAzure } from "../common/utilities";
+import { loginAzure, setAzureCloudBasedOnServiceEndpoint } from "../common/utilities";
 
 async function run() {
     try {
@@ -12,6 +12,7 @@ async function run() {
         }
 
         if (tl.getBoolInput('useazurerm', true)) {
+            setAzureCloudBasedOnServiceEndpoint();
             loginAzure();
         }
 

--- a/v2/terraformworkspace/index.ts
+++ b/v2/terraformworkspace/index.ts
@@ -1,7 +1,7 @@
 import * as tl from 'azure-pipelines-task-lib';
 import fs = require('fs');
 import { WorkspaceCommandBuilder } from "../common/terraformCommandBuilder";
-import { loginAzure } from "../common/utilities";
+import { loginAzure, setAzureCloudBasedOnServiceEndpoint } from "../common/utilities";
 
 async function run() {
     try {
@@ -11,6 +11,7 @@ async function run() {
         }
 
         if (tl.getBoolInput('useazurerm', true)) {
+            setAzureCloudBasedOnServiceEndpoint();
             loginAzure();
         }
 


### PR DESCRIPTION
Hello LouisG,

I am now using your Azure DevOps Extension for a longer time and like it much. Recently while doing a deployment to Azure China I noticed that the extension does not support to change the cloud instance, even though the service connection in Azure DevOps is configured correctly.

I have updated the source code of the extension to support changing the cloud instance.

The code compiles fine on my system with the latest version of NoeJS (6.14.4). Please note that I had to update the version of @types/node to the latest version for that. All other dependencies have been unchanged. Moreover, packaging an Azure DevOps extension with the tfx tool succeeded after that.

Unfortunately I was not able to test the unreleased code since I could not mock service connections in Azure DevOps and I did not want to release your code under my name.

Would be great if you could create a new release with my changes included. Please let me know if you do so. Then I will definitely test the code in one of my projects.

In case you don’t want to release the updated code, then please grant me the permission to create my own release based on your code.

Thanks and regards,
Matthias